### PR TITLE
fix: load brcmfmac on boot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,3 +27,8 @@ chmod +x /tmp/1password.sh && \
   GID_ONEPASSWORD=1500 \
   GID_ONEPASSWORDCLI=1600 \
   /tmp/1password.sh
+
+### activate brcmfmac module on boot
+# workaround for broadcom-wl shenanigans in bluefin and aurora
+# https://github.com/ublue-os/bluefin/issues/1783#issuecomment-2546018436
+touch /usr/lib/{NetworkManager/conf.d/90-broadcom-wl.conf,modprobe.d/broadcom-wl-blacklist.conf}


### PR DESCRIPTION
Due to `broadcom-wl` blocklisting `brcmfmac`, the latter is not loaded on boot. Creating empty files is supposed to be a workaround for the blocklisting.

More details in https://github.com/ublue-os/bluefin/issues/1783#issuecomment-2546018436